### PR TITLE
Add printf format attribute to log_msg

### DIFF
--- a/src/pwaccessd.c
+++ b/src/pwaccessd.c
@@ -25,6 +25,8 @@
 #define USEC_PER_SEC  ((uint64_t) 1000000ULL)
 #define DEFAULT_EXIT_USEC (30*USEC_PER_SEC)
 
+static void log_msg (int, const char *, ...) __attribute__ ((__format__ (__printf__, 2, 3)));
+
 static int log_level = LOG_WARNING;
 static int socket_activation = false;
 
@@ -274,7 +276,7 @@ vl_method_get_user_record(sd_varlink *link, sd_json_variant *parameters,
       return r;
     }
 
-  log_msg(LOG_DEBUG, "GetUserRecord(%li,%s)", p.uid, strna(p.name));
+  log_msg(LOG_DEBUG, "GetUserRecord(%" PRId64 ",%s)", p.uid, strna(p.name));
 
   if (p.uid == -1 && (p.name == NULL || isempty(p.name)))
     {
@@ -302,7 +304,7 @@ vl_method_get_user_record(sd_varlink *link, sd_json_variant *parameters,
     {
       if (errno == 0)
 	{
-	  log_msg(LOG_INFO, "User (%ld|%s) not found", p.uid, strna(p.name));
+	  log_msg(LOG_INFO, "User (%" PRId64 "|%s) not found", p.uid, strna(p.name));
 	  return sd_varlink_errorbo(link, "org.openSUSE.pwaccess.NoEntryFound",
 				    SD_JSON_BUILD_PAIR_BOOLEAN("Success", false));
 	}
@@ -674,7 +676,7 @@ vl_method_expired_check(sd_varlink *link, sd_json_variant *parameters,
 				SD_JSON_BUILD_PAIR_STRING("ErrorMsg", stroom(error)));
     }
 
-  log_msg(LOG_DEBUG, "expired_check(%s): expired: %d, daysleft: %d", p.name, r, daysleft);
+  log_msg(LOG_DEBUG, "expired_check(%s): expired: %d, daysleft: %ld", p.name, r, daysleft);
   return sd_varlink_replybo(link,
 			    SD_JSON_BUILD_PAIR_BOOLEAN("Success", true),
 			    SD_JSON_BUILD_PAIR_INTEGER("DaysLeft", daysleft),

--- a/src/pwaccessd.c
+++ b/src/pwaccessd.c
@@ -536,7 +536,7 @@ vl_method_verify_password(sd_varlink *link, sd_json_variant *parameters,
     {
       if (r == VERIFY_FAILED) /* password does not match */
 	{
-	  log_msg(LOG_DEBUG, "verify_password (%s): password does not match", p.name);
+	  log_msg(LOG_DEBUG, "verify_password (%s): password does not match", strna(p.name));
 	  return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_BOOLEAN("Success", false));
 	}
       else /* libcrypt/internal error */
@@ -555,7 +555,7 @@ vl_method_verify_password(sd_varlink *link, sd_json_variant *parameters,
 	}
     }
 
-  log_msg(LOG_DEBUG, "verify_password (%s): password matches", p.name);
+  log_msg(LOG_DEBUG, "verify_password (%s): password matches", strna(p.name));
   return sd_varlink_replybo(link, SD_JSON_BUILD_PAIR_BOOLEAN("Success", true));
 }
 
@@ -676,7 +676,7 @@ vl_method_expired_check(sd_varlink *link, sd_json_variant *parameters,
 				SD_JSON_BUILD_PAIR_STRING("ErrorMsg", stroom(error)));
     }
 
-  log_msg(LOG_DEBUG, "expired_check(%s): expired: %d, daysleft: %ld", p.name, r, daysleft);
+  log_msg(LOG_DEBUG, "expired_check(%s): expired: %d, daysleft: %ld", strna(p.name), r, daysleft);
   return sd_varlink_replybo(link,
 			    SD_JSON_BUILD_PAIR_BOOLEAN("Success", true),
 			    SD_JSON_BUILD_PAIR_INTEGER("DaysLeft", daysleft),

--- a/src/pwaccessd.c
+++ b/src/pwaccessd.c
@@ -292,7 +292,7 @@ vl_method_get_user_record(sd_varlink *link, sd_json_variant *parameters,
     }
 
   struct passwd *pw = NULL;
-  errno = 0; /* to find out if getpwuid/getpwnam succeed and there is no entry of if there was an error */
+  errno = 0; /* to find out if getpwuid/getpwnam succeed and there is no entry if there was an error */
   if (p.uid != -1)
     pw = getpwuid(p.uid);
   else
@@ -811,7 +811,7 @@ run_varlink (void)
   r = sd_varlink_server_listen_auto (varlink_server);
   if (r < 0)
     {
-      log_msg (LOG_ERR, "Failed to listens: %s", strerror (-r));
+      log_msg (LOG_ERR, "Failed to listen: %s", strerror (-r));
       return r;
     }
 

--- a/src/pwaccessd.c
+++ b/src/pwaccessd.c
@@ -362,7 +362,7 @@ vl_method_get_user_record(sd_varlink *link, sd_json_variant *parameters,
       if (asprintf(&error, "JSON merge object passwd failed: %s",
 		   strerror(-r)) < 0)
 	error = NULL;
-      log_msg(LOG_ERR, "%s", error);
+      log_msg(LOG_ERR, "%s", stroom(error));
       return sd_varlink_errorbo(link, "org.openSUSE.pwaccess.InternalError",
 				SD_JSON_BUILD_PAIR_BOOLEAN("Success", false),
 				SD_JSON_BUILD_PAIR_STRING("ErrorMsg", stroom(error)));
@@ -386,7 +386,7 @@ vl_method_get_user_record(sd_varlink *link, sd_json_variant *parameters,
 	  if (asprintf(&error, "JSON merge object shadow failed: %s",
 		       strerror(-r)) < 0)
 	    error = NULL;
-	  log_msg(LOG_ERR, "%s", error);
+	  log_msg(LOG_ERR, "%s", stroom(error));
 	  return sd_varlink_errorbo(link, "org.openSUSE.pwaccess.InternalError",
 				    SD_JSON_BUILD_PAIR_BOOLEAN("Success", false),
 				    SD_JSON_BUILD_PAIR_STRING("ErrorMsg", stroom(error)));
@@ -406,7 +406,7 @@ vl_method_get_user_record(sd_varlink *link, sd_json_variant *parameters,
       if (asprintf(&error, "JSON merge result object failed: %s",
 		   strerror(-r)) < 0)
 	error = NULL;
-      log_msg(LOG_ERR, "%s", error);
+      log_msg(LOG_ERR, "%s", stroom(error));
       return sd_varlink_errorbo(link, "org.openSUSE.pwaccess.InternalError",
 				SD_JSON_BUILD_PAIR_BOOLEAN("Success", false),
 				SD_JSON_BUILD_PAIR_STRING("ErrorMsg", stroom(error)));


### PR DESCRIPTION
Modern compilers are very useful in discovering issues with formatters. Use them by applying the attribute.

I have fixed uncovered issues for 32 and 64 bit systems.

Also, use stroom and strnan more often. Only a few cases in code missed them.