### PR TITLE
{pwupdd, passwd}: link libcrypt to fix build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -149,7 +149,7 @@ executable('pwupdd',
            pwupdd_c,
            include_directories : inc,
 	   link_with : [libcommon, libpwaccess],
-	   dependencies : [libpam, libsystemd, libeconf, libselinux],
+	   dependencies : [libpam, libsystemd, libeconf, libselinux, libcrypt],
            install_dir : libexecdir,
            install : true)
 
@@ -192,7 +192,7 @@ executable('chsh', 'src/chsh.c', 'src/get_value.c',
 executable('passwd', 'src/passwd.c',
            include_directories : inc,
            link_with : [libcommon, libpwaccess],
-           dependencies : [libsystemd, libpam, libpam_misc, libeconf],
+           dependencies : [libsystemd, libpam, libpam_misc, libeconf, libcrypt],
            install : true)
 executable('expiry', 'src/expiry.c',
            include_directories : inc,


### PR DESCRIPTION
- compiler is complaining about missing symbol `bool`, so include the `stdbool.h` header.
- `pwupdd` fails to link against `crypt`, because the dependency is not listed in meson

Motivation: LLVM+musl NixOS systems have broken SUID binaries, so just as an experiment i wanted to see whether i could get an interactive login shell to work based on `pwaccess`. That setup is inherently cursed, so i expect I'll have more fixes than this. For now, these are just what is needed to make `pwaccess` build in our  standard environment.