### PR TITLE
systemd: use libexecdir as configured in meson to template binary paths

### DIFF
--- a/units/meson.build
+++ b/units/meson.build
@@ -1,4 +1,21 @@
-install_data('pwaccessd.service', install_dir : systemunitdir)
+configure_file(
+  input: 'pwaccessd.service.in',
+  output: 'pwaccessd.service',
+  configuration: {
+    'LIBEXECDIR': libexecdir,
+  },
+  install: true,
+  install_dir: systemunitdir,
+)
 install_data('pwaccessd.socket', install_dir : systemunitdir)
-install_data('pwupdd@.service', install_dir : systemunitdir)
+
+configure_file(
+  input: 'pwupdd@.service.in',
+  output: 'pwupdd@.service',
+  configuration: {
+    'LIBEXECDIR': libexecdir,
+  },
+  install: true,
+  install_dir: systemunitdir,
+)
 install_data('pwupdd.socket', install_dir : systemunitdir)

--- a/units/pwaccessd.service.in
+++ b/units/pwaccessd.service.in
@@ -6,7 +6,7 @@ Documentation=man:pwaccessd(8)
 Type=notify
 Environment="PWACCESSD_OPTS="
 EnvironmentFile=-/etc/default/pwaccessd
-ExecStart=/usr/libexec/pwaccessd -s $PWACCESSD_OPTS
+ExecStart=@LIBEXECDIR@/pwaccessd -s $PWACCESSD_OPTS
 IPAddressDeny=any
 LockPersonality=yes
 MemoryDenyWriteExecute=yes

--- a/units/pwupdd@.service.in
+++ b/units/pwupdd@.service.in
@@ -3,4 +3,4 @@ Description=Daemon to update passwd and shadow entries
 After=local-fs.target
 
 [Service]
-ExecStart=/usr/libexec/pwupdd -d
+ExecStart=@LIBEXECDIR@/pwupdd -d


### PR DESCRIPTION
NixOS does not have the standard FHS paths such as `/usr/libexec`. However, meson does know about  `libexecdir`, so we should just use templates for that.