### PR TITLE
pam_unix_ng: add missing time header

### DIFF
--- a/src/pam_unix_ng.h
+++ b/src/pam_unix_ng.h
@@ -6,6 +6,7 @@
 #include <syslog.h>
 #include <security/pam_modules.h>
 #include <security/pam_ext.h>
+#include <time.h>
 
 #define ARG_DEBUG	1 /* send info to syslog(3) */
 #define ARG_QUIET	2 /* keep quiet about things */


### PR DESCRIPTION
This header is indirectly included on glibc, but not on musl. This header provides the `timespec` type, which is actually used.

Obviously `fgetspent_r` / `fgetpwent_r` is still broken. Implementations for those were proposed at upstream musl, but never merged. There is tricks one can do, but i don't feel confident doing a PR for those yet. But, missing includes are trivial to fix, so i may as well add this one, means the patch stack is more manageable.