### PR TITLE
dump-privs: add missing stdbool include

### DIFF
--- a/dump-privs/dump-privs.c
+++ b/dump-privs/dump-privs.c
@@ -10,6 +10,7 @@
 #include <unistd.h>
 #include <getopt.h>
 #include <sys/prctl.h>
+#include <stdbool.h>
 #ifdef WITH_SELINUX
 #include <selinux/selinux.h>
 #endif


### PR DESCRIPTION
This header is implicitly included with glibc, but would be missing on musl. The class uses booleans in `main` for `wait` and `printenv`, so the header should be included explicitly.